### PR TITLE
Refactor auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,11 @@ You should see a response like this:
 "{\"ok\":true,\"id\":\"42\",\"rev\":\"2-9b2e3bcc3752a3...\"}\n"
 ```
 
-Note that there is a second clause that taks in basic authentication information to allow authentication against a secured database.
+Basic authentication information need to be put in the database properties:
+
+```Elixir
+db_props = %{protocol: "http", hostname: "localhost", database: "couchdb_connector_dev", port: 5984, user: "admin", password: "secret"}
+```
 
 ### Delete a document — Response wrapped in a Map
 

--- a/lib/couchdb_connector/admin.ex
+++ b/lib/couchdb_connector/admin.ex
@@ -55,13 +55,25 @@ defmodule Couchdb.Connector.Admin do
   the function will respond with {:ok, body, headers}. In case of failures (e.g.
   if user already exists), the response will be {:error, body, headers}.
   """
-  @spec create_user(Types.db_properties, Types.basic_auth, Types.basic_auth, Types.user_roles)
+  @spec create_user(Types.db_properties, Types.user_info, Types.user_roles)
     :: {:ok, String.t, Types.headers} | {:error, String.t, Types.headers}
-  def create_user(db_props, admin_auth, user_auth, roles) do
+  def create_user(db_props, user_auth, roles) do
     db_props
-    |> UrlHelper.user_url(admin_auth, user_auth[:user])
+    |> UrlHelper.user_url(user_auth[:user])
     |> do_create_user(user_to_json(user_auth, roles))
     |> Handler.handle_put(:include_headers)
+  end
+
+  @doc """
+  Create a new user with given username, password and roles. In case of success,
+  the function will respond with {:ok, body, headers}. In case of failures (e.g.
+  if user already exists), the response will be {:error, body, headers}.
+  """
+  @spec create_user(Types.db_properties, Types.basic_auth, Types.user_info, Types.user_roles)
+    :: {:ok, String.t, Types.headers} | {:error, String.t, Types.headers}
+  def create_user(db_props, admin_auth, user_auth, roles) do
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Admin.create_user/4 is deprecated, please use create_user/3 instead\n"
+    create_user(Map.merge(db_props, admin_auth), user_auth, roles)
   end
 
   defp do_create_user(url, json) do
@@ -80,12 +92,12 @@ defmodule Couchdb.Connector.Admin do
   the function will respond with an empty body. In case of failures (e.g.
   if admin already exists), the response will be {:error, body, headers}.
   """
-  @spec create_admin(Types.db_properties, Types.basic_auth)
+  @spec create_admin(Types.db_properties, Types.user_info)
     :: {:ok, String.t, Types.headers} | {:error, String.t, Types.headers}
-  def create_admin(db_props, admin_auth) do
+  def create_admin(db_props, admin_info) do
     db_props
-    |> UrlHelper.admin_url(admin_auth[:user])
-    |> do_create_admin(admin_auth[:password])
+    |> UrlHelper.admin_url(admin_info[:user])
+    |> do_create_admin(admin_info[:password])
     |> Handler.handle_put(:include_headers)
   end
 
@@ -97,11 +109,35 @@ defmodule Couchdb.Connector.Admin do
   Returns the public information for the given user or an error in case the
   user does not exist.
   """
+  @spec user_info(Types.db_properties, String.t)
+    :: {:ok, String.t} | {:error, String.t}
+  def user_info(db_props, username) do
+    db_props
+    |> UrlHelper.user_url(username)
+    |> HTTPoison.get!
+    |> Handler.handle_get
+  end
+
+  @doc """
+  Returns the public information for the given user or an error in case the
+  user does not exist.
+  """
   @spec user_info(Types.db_properties, Types.basic_auth, String.t)
     :: {:ok, String.t} | {:error, String.t}
   def user_info(db_props, admin_auth, username) do
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Admin.user_info/3 is deprecated, please use user_info/2 instead\n"
+    user_info(Map.merge(db_props, admin_auth), username)
+  end
+
+  @doc """
+  Returns hashed information for the given admin or an error in case the admin
+  does not exist or if the given credentials are wrong.
+  """
+  @spec admin_info(Types.db_properties)
+    :: {:ok, String.t} | {:error, String.t}
+  def admin_info db_props do
     db_props
-    |> UrlHelper.user_url(admin_auth, username)
+    |> UrlHelper.admin_url(db_props[:user])
     |> HTTPoison.get!
     |> Handler.handle_get
   end
@@ -113,10 +149,23 @@ defmodule Couchdb.Connector.Admin do
   @spec admin_info(Types.db_properties, Types.basic_auth)
     :: {:ok, String.t} | {:error, String.t}
   def admin_info db_props, admin_auth do
-    db_props
-    |> UrlHelper.admin_url(admin_auth[:user], admin_auth[:password])
-    |> HTTPoison.get!
-    |> Handler.handle_get
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Admin.admin_info/2 is deprecated, please use admin_info/1 instead\n"
+    admin_info(Map.merge(db_props, admin_auth))
+  end
+
+  @doc """
+  Deletes the given user from the database server or returns an error in case
+  the user cannot be found. Requires admin basic auth credentials.
+  """
+  @spec destroy_user(Types.db_properties, String.t)
+  :: {:ok, String.t} | {:error, String.t}
+  def destroy_user(db_props, username) do
+    case user_info(db_props, username) do
+      {:ok, user_json} ->
+        user = Poison.decode! user_json
+        do_destroy_user(db_props, username, user["_rev"])
+      error -> error
+    end
   end
 
   @doc """
@@ -126,17 +175,13 @@ defmodule Couchdb.Connector.Admin do
   @spec destroy_user(Types.db_properties, Types.basic_auth, String.t)
   :: {:ok, String.t} | {:error, String.t}
   def destroy_user(db_props, admin_auth, username) do
-    case user_info(db_props, admin_auth, username) do
-      {:ok, user_json} ->
-        user = Poison.decode! user_json
-        do_destroy_user(db_props, admin_auth, username, user["_rev"])
-      error -> error
-    end
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Admin.destroy_user/3 is deprecated, please use destroy_user/3 instead\n"
+    destroy_user(Map.merge(db_props, admin_auth), username)
   end
 
-  defp do_destroy_user(db_props, admin_auth, username, rev) do
+  defp do_destroy_user(db_props, username, rev) do
     db_props
-    |> UrlHelper.user_url(admin_auth, username)
+    |> UrlHelper.user_url(username)
     |> do_http_delete(rev)
     |> Handler.handle_delete
   end
@@ -162,6 +207,21 @@ defmodule Couchdb.Connector.Admin do
     |> Handler.handle_delete
   end
 
+
+  @doc """
+  Set the security object for a given database. Security object includes admins
+  and members for the database.
+  """
+  # TODO: add user roles
+  @spec set_security(Types.db_properties, list(String.t), list(String.t))
+    :: {:ok, String.t} | {:error, String.t}
+  def set_security(db_props, admins, members) do
+    db_props
+    |> UrlHelper.security_url
+    |> do_set_security(security_to_json(admins, members))
+    |> Handler.handle_put
+  end
+
   @doc """
   Set the security object for a given database. Security object includes admins
   and members for the database.
@@ -170,10 +230,8 @@ defmodule Couchdb.Connector.Admin do
   @spec set_security(Types.db_properties, Types.basic_auth, list(String.t), list(String.t))
     :: {:ok, String.t} | {:error, String.t}
   def set_security(db_props, admin_auth, admins, members) do
-    db_props
-    |> UrlHelper.security_url(admin_auth)
-    |> do_set_security(security_to_json(admins, members))
-    |> Handler.handle_put
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Admin.set_security/4 is deprecated, please use set_security/3 instead\n"
+    set_security(Map.merge(db_props, admin_auth), admins, members)
   end
 
   defp do_set_security(url, json) do

--- a/lib/couchdb_connector/reader.ex
+++ b/lib/couchdb_connector/reader.ex
@@ -41,9 +41,8 @@ defmodule Couchdb.Connector.Reader do
   """
   @spec get(Types.db_properties, Types.basic_auth, String.t) :: {:ok, String.t} | {:error, String.t}
   def get(db_props, basic_auth, id) do
-    db_props
-    |> UrlHelper.document_url(basic_auth, id)
-    |> do_get
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Reader.get/3 is deprecated, please use get/2 instead\n"
+    get(Map.merge(db_props, basic_auth), id)
   end
 
   @doc """

--- a/lib/couchdb_connector/storage.ex
+++ b/lib/couchdb_connector/storage.ex
@@ -32,10 +32,8 @@ defmodule Couchdb.Connector.Storage do
   using the provided basic authentication parameters.
   """
   def storage_up db_props, auth do
-    db_props
-    |> UrlHelper.database_url(auth)
-    |> HTTPoison.put!("{}", [Headers.json_header])
-    |> Handler.handle_put
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Storage.storage_up/2 is deprecated, please use storage_up/1 instead\n"
+    storage_up(Map.merge(db_props, auth))
   end
 
   @doc """
@@ -53,9 +51,7 @@ defmodule Couchdb.Connector.Storage do
   using the provided basic authentication parameters.
   """
   def storage_down db_props, auth do
-    db_props
-    |> UrlHelper.database_url(auth)
-    |> HTTPoison.delete!
-    |> Handler.handle_delete
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Storage.storage_down/2 is deprecated, please use storage_down/1 instead\n"
+    storage_down(Map.merge(db_props, auth))
   end
 end

--- a/lib/couchdb_connector/types.ex
+++ b/lib/couchdb_connector/types.ex
@@ -8,7 +8,8 @@ defmodule Couchdb.Connector.Types do
   Database properties: host, port, protocol (http|https), database name
   """
   @type db_properties :: %{protocol: String.t, hostname: String.t,
-                           database: String.t, port: non_neg_integer}
+                           database: String.t, port: non_neg_integer,
+                           user: String.t, password: String.t}
 
   @typedoc "CouchDB user role is just a string, user_roles a list of strings."
   @type user_roles :: [String.t]

--- a/lib/couchdb_connector/types.ex
+++ b/lib/couchdb_connector/types.ex
@@ -20,6 +20,9 @@ defmodule Couchdb.Connector.Types do
   @typedoc "Username and password for basic authentication"
   @type basic_auth :: %{user: String.t, password: String.t}
 
+  @typedoc "User information"
+  @type user_info :: %{user: String.t, password: String.t}
+
   @typedoc """
   Design name, view name and lookup key are often used together in view
   queries so it makes sense to wrap them in a type.

--- a/lib/couchdb_connector/url_helper.ex
+++ b/lib/couchdb_connector/url_helper.ex
@@ -1,4 +1,6 @@
 defmodule Couchdb.Connector.UrlHelper do
+  @default_db_properties %{user: nil, password: nil}
+
   @moduledoc """
   Provides URL helper functions that compose URLs based on given database
   properties and additional parameters, such as document IDs, usernames, etc.
@@ -14,7 +16,7 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec database_server_url(Types.db_properties) :: String.t
   def database_server_url db_props do
-    "#{db_props[:protocol]}://#{db_props[:hostname]}:#{db_props[:port]}"
+    @default_db_properties |> Map.merge(db_props) |> do_database_server_url
   end
 
   @doc """
@@ -23,7 +25,16 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec database_server_url(Types.db_properties, Types.basic_auth) :: String.t
   def database_server_url(db_props, auth) do
-    "#{db_props[:protocol]}://#{auth[:user]}:#{auth[:password]}@#{db_props[:hostname]}:#{db_props[:port]}"
+    IO.write :stderr, "\nwarning: Couchdb.Connector.UrlHelper.database_server_url/2 is deprecated, please use database_server_url/1 instead\n"
+    database_server_url(Map.merge(db_props, auth))
+  end
+
+  defp do_database_server_url db_props = %{user: nil} do
+    "#{db_props[:protocol]}://#{db_props[:hostname]}:#{db_props[:port]}"
+  end
+
+  defp do_database_server_url db_props do
+    "#{db_props[:protocol]}://#{db_props[:user]}:#{db_props[:password]}@#{db_props[:hostname]}:#{db_props[:port]}"
   end
 
   @doc """
@@ -40,7 +51,8 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec database_url(Types.db_properties, Types.basic_auth) :: String.t
   def database_url(db_props, auth) do
-    "#{database_server_url(db_props, auth)}/#{db_props[:database]}"
+    IO.write :stderr, "\nwarning: Couchdb.Connector.UrlHelper.database_url/2 is deprecated, please use database_url/1 instead\n"
+    database_url(Map.merge(db_props, auth))
   end
 
   @doc """
@@ -57,7 +69,8 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec document_url(Types.db_properties, Types.basic_auth, String.t) :: String.t
   def document_url(db_props, auth, id) do
-    "#{database_url(db_props, auth)}/#{id}"
+    IO.write :stderr, "\nwarning: Couchdb.Connector.UrlHelper.document_url/3 is deprecated, please use document_url/2 instead\n"
+    document_url(Map.merge(db_props, auth), id)
   end
 
   @doc """
@@ -82,7 +95,8 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec design_url(Types.db_properties, Types.basic_auth, String.t) :: String.t
   def design_url db_props, auth, design do
-    "#{database_server_url(db_props, auth)}/#{db_props[:database]}/_design/#{design}"
+    IO.write :stderr, "\nwarning: Couchdb.Connector.UrlHelper.design_url/3 is deprecated, please use design_url/2 instead\n"
+    design_url(Map.merge(db_props, auth), design)
   end
 
   @doc """
@@ -100,7 +114,8 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec view_url(Types.db_properties, Types.basic_auth, String.t, String.t) :: String.t
   def view_url db_props, auth, design, view do
-    "#{design_url(db_props, auth, design)}/_view/#{view}"
+    IO.write :stderr, "\nwarning: Couchdb.Connector.UrlHelper.view_url/4 is deprecated, please use view_url/3 instead\n"
+    view_url(Map.merge(db_props, auth), design, view)
   end
 
   @doc """
@@ -126,7 +141,8 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec user_url(Types.db_properties, Types.basic_auth, String.t) :: String.t
   def user_url(db_props, admin_auth, username) do
-    "#{database_server_url(db_props, admin_auth)}/_users/org.couchdb.user:#{username}"
+    IO.write :stderr, "\nwarning: Couchdb.Connector.UrlHelper.user_url/3 is deprecated, please use user_url/2 instead\n"
+    user_url(Map.merge(db_props, admin_auth), username)
   end
 
   @doc """
@@ -142,7 +158,17 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec admin_url(Types.db_properties, String.t, String.t) :: String.t
   def admin_url db_props, admin_name, password do
-    "#{database_server_url(db_props, %{user: admin_name, password: password})}/_config/admins/#{admin_name}"
+    admin_url(Map.merge(db_props, %{user: admin_name, password: password}), admin_name)
+  end
+
+
+  @doc """
+  Produces the URL to the database's security object. Requires admin
+  credentials.
+  """
+  @spec security_url(Types.db_properties) :: String.t
+  def security_url db_props do
+    "#{database_url(db_props)}/_security"
   end
 
   @doc """
@@ -151,6 +177,7 @@ defmodule Couchdb.Connector.UrlHelper do
   """
   @spec security_url(Types.db_properties, Types.basic_auth) :: String.t
   def security_url db_props, admin_auth do
-    "#{database_url(db_props, admin_auth)}/_security"
+    IO.write :stderr, "\nwarning: Couchdb.Connector.UrlHelper.security_url/2 is deprecated, please use security_url/1 instead\n"
+    security_url(Map.merge(db_props, admin_auth))
   end
 end

--- a/lib/couchdb_connector/view.ex
+++ b/lib/couchdb_connector/view.ex
@@ -37,10 +37,8 @@ defmodule Couchdb.Connector.View do
   """
   @spec fetch_all(Types.db_properties, Types.basic_auth, String.t, String.t) :: {:ok, String.t} | {:error, String.t}
   def fetch_all(db_props, auth, design, view) do
-    db_props
-    |> UrlHelper.view_url(auth, design, view)
-    |> HTTPoison.get!
-    |> Handler.handle_get
+    IO.write :stderr, "\nwarning: Couchdb.Connector.View.fetch_all/4 is deprecated, please use fetch_all/3 instead\n"
+    fetch_all(Map.merge(db_props, auth), design, view)
   end
 
   @doc """
@@ -49,10 +47,8 @@ defmodule Couchdb.Connector.View do
   """
   @spec create_view(Types.db_properties, Types.basic_auth, String.t, String.t) :: {:ok, String.t} | {:error, String.t}
   def create_view(db_props, admin_auth, design, code) do
-    db_props
-    |> UrlHelper.design_url(admin_auth, design)
-    |> HTTPoison.put!(code)
-    |> Handler.handle_put
+    IO.write :stderr, "\nwarning: Couchdb.Connector.View.create_view/4 is deprecated, please use create_view/3 instead\n"
+    create_view(Map.merge(db_props, admin_auth), design, code)
   end
 
   @doc """
@@ -76,8 +72,10 @@ defmodule Couchdb.Connector.View do
   """
   @spec document_by_key(Types.db_properties, Types.basic_auth, Types.view_key, :update_after)
     :: {:ok, String.t} | {:error, String.t}
-  def document_by_key(db_props, auth, view_key, :update_after),
-    do: authenticated_document_by_key(db_props, auth, view_key, :update_after)
+  def document_by_key(db_props, auth, view_key, :update_after) do
+    IO.write :stderr, "\nwarning: Couchdb.Connector.View.document_by_key/4 is deprecated, please use document_by_key/3 instead\n"
+    document_by_key(Map.merge(db_props, auth), view_key, :update_after)
+  end
 
   @doc """
   Find and return one document with given key in given view, using basic
@@ -89,14 +87,15 @@ defmodule Couchdb.Connector.View do
   """
   @spec document_by_key(Types.db_properties, Types.basic_auth, Types.view_key, :ok)
     :: {:ok, String.t} | {:error, String.t}
-  def document_by_key(db_props, auth, view_key, :ok),
-    do: authenticated_document_by_key(db_props, auth, view_key, :ok)
+  def document_by_key(db_props, auth, view_key, :ok) do
+    IO.write :stderr, "\nwarning: Couchdb.Connector.View.document_by_key/4 is deprecated, please use document_by_key/3 instead\n"
+    document_by_key(Map.merge(db_props, auth), view_key, :ok)
+  end
 
+  # TODO: evaluate if this method actually needs to be public, otherwise delete
   def authenticated_document_by_key(db_props, auth, view_key, stale) do
-    db_props
-    |> UrlHelper.view_url(auth, view_key[:design], view_key[:view])
-    |> UrlHelper.query_path(view_key[:key], stale)
-    |> do_document_by_key
+    IO.write :stderr, "\nwarning: Couchdb.Connector.View.authenticated_document_by_key/4 is deprecated, please use unauthenticated_document_by_key/3 instead\n"
+    unauthenticated_document_by_key(Map.merge(db_props, auth), view_key, stale)
   end
 
   @doc """
@@ -141,9 +140,12 @@ defmodule Couchdb.Connector.View do
   """
   @spec document_by_key(Types.db_properties, Types.basic_auth, Types.view_key)
     :: {:ok, String.t} | {:error, String.t}
-  def document_by_key(db_props, auth, view_key) when is_map(auth),
-    do: document_by_key(db_props, auth, view_key, :update_after)
+  def document_by_key(db_props, auth, view_key) when is_map(auth) do
+    IO.write :stderr, "\nwarning: Couchdb.Connector.View.document_by_key/3 is deprecated, please use document_by_key/2 instead\n"
+    document_by_key(Map.merge(db_props, auth), view_key)
+  end
 
+  # TODO as with the new api, this method can be used authenticated and unauthenticated
   def unauthenticated_document_by_key(db_props, view_key, stale) do
     db_props
     |> UrlHelper.view_url(view_key[:design], view_key[:view])

--- a/lib/couchdb_connector/writer.ex
+++ b/lib/couchdb_connector/writer.ex
@@ -39,9 +39,8 @@ defmodule Couchdb.Connector.Writer do
   @spec create(Types.db_properties, Types.basic_auth, String.t, String.t)
     :: {:ok, String.t, Types.headers} | {:error, String.t, Types.headers}
   def create(db_props, auth, json, id) do
-    db_props
-    |> UrlHelper.document_url(auth, id)
-    |> do_create(json)
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Writer.create/4 is deprecated, please use create/3 instead\n"
+    create(Map.merge(db_props, auth), json, id)
   end
 
   @doc """
@@ -68,9 +67,8 @@ defmodule Couchdb.Connector.Writer do
   @spec create_generate(Types.db_properties, Types.basic_auth, String.t)
     :: {:ok, String.t, Types.headers} | {:error, String.t, Types.headers}
   def create_generate(db_props, auth, json) do
-    {:ok, uuid_json} = Reader.fetch_uuid(db_props)
-    uuid = hd(Poison.decode!(uuid_json)["uuids"])
-    create(db_props, auth, json, uuid)
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Writer.create_generate/3 is deprecated, please use create_generate/2 instead\n"
+    create_generate(Map.merge(db_props, auth), json)
   end
 
   @doc """
@@ -123,16 +121,8 @@ defmodule Couchdb.Connector.Writer do
   @spec update(Types.db_properties, Types.basic_auth, String.t)
     :: {:ok, String.t, Types.headers} | {:error, String.t, Types.headers}
   def update(db_props, auth, json) when is_map(auth) do
-    {doc_map, id} = parse_and_extract_id(json)
-    case id do
-      {:ok, id} ->
-        db_props
-        |> UrlHelper.document_url(auth, id)
-        |> do_update(Poison.encode!(doc_map))
-      :error ->
-        raise RuntimeError, message:
-          "the document to be updated must contain an \"_id\" field"
-    end
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Write.update/3 is deprecated, please use update/2 instead\n"
+    update(Map.merge(db_props, auth), json)
   end
 
   @doc """
@@ -174,9 +164,8 @@ defmodule Couchdb.Connector.Writer do
   @spec update(Types.db_properties, Types.basic_auth, String.t, String.t)
     :: {:ok, String.t, Types.headers} | {:error, String.t, Types.headers}
   def update(db_props, auth, json, id) do
-    db_props
-    |> UrlHelper.document_url(auth, id)
-    |> do_update(json)
+    IO.write :stderr, "\nwarning: Couchdb.Connector.Write.update/4 is deprecated, please use update/3 instead\n"
+    update(Map.merge(db_props, auth), json, id)
   end
 
   defp do_update(url, json) do

--- a/test/couchdb_connector/admin_test.exs
+++ b/test/couchdb_connector/admin_test.exs
@@ -6,7 +6,6 @@ defmodule Couchdb.Connector.AdminTest do
   alias Couchdb.Connector.TestConfig
   alias Couchdb.Connector.TestPrep
   alias Couchdb.Connector.UrlHelper
-  alias Couchdb.Connector.TestSupport
 
   setup context do
     on_exit context, fn ->
@@ -19,7 +18,7 @@ defmodule Couchdb.Connector.AdminTest do
   test "create_user/4: ensure that a new user gets created with given parameters" do
     TestPrep.ensure_test_admin
     {:ok, body, headers} = Admin.create_user(
-      TestConfig.database_properties, TestSupport.test_admin, TestSupport.test_user, ["couchdb contributor"])
+      TestConfig.database_properties, TestConfig.test_admin, TestConfig.test_user, ["couchdb contributor"])
     {:ok, body_map} = Poison.decode body
     assert body_map["id"] == "org.couchdb.user:jan"
     assert header_value(headers, "Location") == UrlHelper.user_url(TestConfig.database_properties, "jan")
@@ -28,7 +27,7 @@ defmodule Couchdb.Connector.AdminTest do
   test "user_info/3: get public information for given username" do
     TestPrep.ensure_test_admin
     TestPrep.ensure_test_user
-    {:ok, body} = Admin.user_info(TestConfig.database_properties, TestSupport.test_admin, "jan")
+    {:ok, body} = Admin.user_info(TestConfig.database_properties, TestConfig.test_admin, "jan")
     {:ok, body_map} = Poison.decode body
     assert body_map["_id"] == "org.couchdb.user:jan"
     assert body_map["roles"] == ["members"]
@@ -36,7 +35,7 @@ defmodule Couchdb.Connector.AdminTest do
 
   test "user_info/3: should return an error when asked for missing user" do
     TestPrep.ensure_test_admin
-    {:error, body} = Admin.user_info(TestConfig.database_properties, TestSupport.test_admin, "jan")
+    {:error, body} = Admin.user_info(TestConfig.database_properties, TestConfig.test_admin, "jan")
     {:ok, body_map} = Poison.decode body
     assert body_map["error"] == "not_found"
   end
@@ -44,7 +43,7 @@ defmodule Couchdb.Connector.AdminTest do
   test "destroy_user/3: ensure that a given user can be deleted" do
     TestPrep.ensure_test_admin
     TestPrep.ensure_test_user
-    {:ok, body} = Admin.destroy_user(TestConfig.database_properties, TestSupport.test_admin, "jan")
+    {:ok, body} = Admin.destroy_user(TestConfig.database_properties, TestConfig.test_admin, "jan")
     {:ok, body_map} = Poison.decode body
     assert body_map["id"] == "org.couchdb.user:jan"
     assert String.starts_with?(body_map["rev"], "2-")
@@ -52,14 +51,14 @@ defmodule Couchdb.Connector.AdminTest do
 
   test "destroy_user/3: should return an error when given non-existing user" do
     TestPrep.ensure_test_admin
-    {:error, body} = Admin.destroy_user(TestConfig.database_properties, TestSupport.test_admin, "jan")
+    {:error, body} = Admin.destroy_user(TestConfig.database_properties, TestConfig.test_admin, "jan")
     {:ok, body_map} = Poison.decode body
     assert body_map["error"] == "not_found"
   end
 
   test "create_admin/2: ensure that a new admin gets created with given parameters" do
     {:ok, body, headers} = Admin.create_admin(
-      TestConfig.database_properties, TestSupport.test_admin)
+      TestConfig.database_properties, TestConfig.test_admin)
     # CouchDB has a peculiar way to respond to successful 'add admin' requests
     # I think it's wrong in doing what it does, but what can you do?
     assert body == "\"\"\n"
@@ -69,19 +68,19 @@ defmodule Couchdb.Connector.AdminTest do
   test "create_admin/2: ensure that same admin cannot be created twice" do
     TestPrep.ensure_test_admin
     {:error, body, _} = Admin.create_admin(
-      TestConfig.database_properties, TestSupport.test_admin)
+      TestConfig.database_properties, TestConfig.test_admin)
     {:ok, body_map} = Poison.decode body
     assert body_map["error"] == "unauthorized"
   end
 
   test "admin_info/2: ensure that an existing admin can retrieve info about herself" do
     TestPrep.ensure_test_admin
-    {:ok, body} = Admin.admin_info(TestConfig.database_properties, TestSupport.test_admin)
+    {:ok, body} = Admin.admin_info(TestConfig.database_properties, TestConfig.test_admin)
     assert body != ""
   end
 
   test "admin_info/2: should return an authorization error when a non-existing admin tries retrieve info about herself" do
-    {:error, body} = Admin.admin_info(TestConfig.database_properties, TestSupport.test_admin)
+    {:error, body} = Admin.admin_info(TestConfig.database_properties, TestConfig.test_admin)
     {:ok, body_map} = Poison.decode body
     assert body_map["error"] == "unauthorized"
   end
@@ -102,7 +101,7 @@ defmodule Couchdb.Connector.AdminTest do
     TestPrep.ensure_database
     TestPrep.ensure_test_admin
     TestPrep.ensure_test_user
-    {:ok, body} = Admin.set_security(TestConfig.database_properties, TestSupport.test_admin, ["anna"], ["jan"])
+    {:ok, body} = Admin.set_security(TestConfig.database_properties, TestConfig.test_admin, ["anna"], ["jan"])
     assert body == "{\"ok\":true}\n"
   end
 end

--- a/test/couchdb_connector/secure_reader_test.exs
+++ b/test/couchdb_connector/secure_reader_test.exs
@@ -5,7 +5,6 @@ defmodule Couchdb.Connector.SecureReaderTest do
   alias Couchdb.Connector.Reader
   alias Couchdb.Connector.TestConfig
   alias Couchdb.Connector.TestPrep
-  alias Couchdb.Connector.TestSupport
 
   setup context do
     TestPrep.ensure_database
@@ -23,7 +22,7 @@ defmodule Couchdb.Connector.SecureReaderTest do
     TestPrep.secure_database
     {:ok, json} = retry_on_error(
       fn() ->
-        Reader.get(TestConfig.database_properties, TestSupport.test_user, "foo")
+        Reader.get(TestConfig.database_properties, TestConfig.test_user, "foo")
       end)
     {:ok, json_map} = Poison.decode json
     assert json_map["test_key"] == "test_value"

--- a/test/couchdb_connector/secure_storage_test.exs
+++ b/test/couchdb_connector/secure_storage_test.exs
@@ -5,7 +5,6 @@ defmodule Couchdb.Connector.SecureStorageTest do
   alias Couchdb.Connector.Storage
   alias Couchdb.Connector.TestConfig
   alias Couchdb.Connector.TestPrep
-  alias Couchdb.Connector.TestSupport
 
   setup context do
     TestPrep.delete_database
@@ -24,32 +23,32 @@ defmodule Couchdb.Connector.SecureStorageTest do
   end
 
   test "storage_up/2: ensure that database can be created" do
-    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestSupport.test_admin
+    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestConfig.test_admin
 
     assert TestConfig.db_exists
   end
 
   test "storage_up/2: verify second attempt at creating a database returns :error" do
-    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestSupport.test_admin
+    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestConfig.test_admin
 
-    { :error, body } = Storage.storage_up TestConfig.database_properties, TestSupport.test_admin
+    { :error, body } = Storage.storage_up TestConfig.database_properties, TestConfig.test_admin
 
     assert String.contains?(body, "file_exists")
   end
 
   test "storage_down/2: ensure that database can be destroyed" do
-    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestSupport.test_admin
+    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestConfig.test_admin
 
-    { :ok, _body } = Storage.storage_down TestConfig.database_properties, TestSupport.test_admin
+    { :ok, _body } = Storage.storage_down TestConfig.database_properties, TestConfig.test_admin
 
     assert !TestConfig.db_exists
   end
 
   test "storage_up/2: verify second attempt at destroying a database returns :error" do
-    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestSupport.test_admin
-    { :ok, _body } = Storage.storage_down TestConfig.database_properties, TestSupport.test_admin
+    { :ok, _body } = Storage.storage_up TestConfig.database_properties, TestConfig.test_admin
+    { :ok, _body } = Storage.storage_down TestConfig.database_properties, TestConfig.test_admin
 
-    { :error, body } = Storage.storage_down TestConfig.database_properties, TestSupport.test_admin
+    { :error, body } = Storage.storage_down TestConfig.database_properties, TestConfig.test_admin
 
     assert String.contains?(body, "not_found")
   end

--- a/test/couchdb_connector/secure_view_test.exs
+++ b/test/couchdb_connector/secure_view_test.exs
@@ -7,7 +7,6 @@ defmodule Couchdb.Connector.SecureViewTest do
   alias Couchdb.Connector.View
   alias Couchdb.Connector.TestConfig
   alias Couchdb.Connector.TestPrep
-  alias Couchdb.Connector.TestSupport
 
   setup context do
     TestPrep.ensure_database
@@ -25,7 +24,7 @@ defmodule Couchdb.Connector.SecureViewTest do
     {:ok, json} = retry_on_error(
       fn() ->
         View.fetch_all(
-          TestConfig.database_properties, TestSupport.test_user, "test_view", "test_fetch")
+          TestConfig.database_properties, TestConfig.test_user, "test_view", "test_fetch")
       end)
     {:ok, result_map} = Poison.decode json
     assert result_map["total_rows"] == 1
@@ -37,7 +36,7 @@ defmodule Couchdb.Connector.SecureViewTest do
     {:ok, code} = File.read("test/resources/views/test_view.json")
     {:ok, result} = retry_on_error(
       fn() -> View.create_view(
-        TestConfig.database_properties, TestSupport.test_admin, "test_design", code)
+        TestConfig.database_properties, TestConfig.test_admin, "test_design", code)
       end)
     assert String.contains?(result, "\"id\":\"_design/test_design\"")
   end
@@ -46,7 +45,7 @@ defmodule Couchdb.Connector.SecureViewTest do
     result = retry(@retries,
       fn(_) ->
         View.document_by_key(
-          TestConfig.database_properties, TestSupport.test_user, TestSupport.test_view_key, :update_after
+          TestConfig.database_properties, TestConfig.test_user, TestConfig.test_view_key, :update_after
         )
       end,
       fn(response) ->
@@ -66,10 +65,10 @@ defmodule Couchdb.Connector.SecureViewTest do
   end
 
   test "document_by_key/3: ensure that function exists. document may or may not be found" do
-    View.document_by_key TestConfig.database_properties, TestSupport.test_user, TestSupport.test_view_key
+    View.document_by_key TestConfig.database_properties, TestConfig.test_user, TestConfig.test_view_key
   end
 
   test "document_by_key/4: ensure that function exists. document may or may not be found" do
-    View.document_by_key TestConfig.database_properties, TestSupport.test_user, TestSupport.test_view_key, :ok
+    View.document_by_key TestConfig.database_properties, TestConfig.test_user, TestConfig.test_view_key, :ok
   end
 end

--- a/test/couchdb_connector/secure_writer_test.exs
+++ b/test/couchdb_connector/secure_writer_test.exs
@@ -6,7 +6,6 @@ defmodule Couchdb.Connector.SecureWriterTest do
   alias Couchdb.Connector.Reader
   alias Couchdb.Connector.TestConfig
   alias Couchdb.Connector.TestPrep
-  alias Couchdb.Connector.TestSupport
 
   setup context do
     TestPrep.ensure_database
@@ -23,7 +22,7 @@ defmodule Couchdb.Connector.SecureWriterTest do
     TestPrep.secure_database
     {:ok, body, headers} = retry_on_error(
       fn() -> Writer.create(
-        TestConfig.database_properties, TestSupport.test_user, "{\"key\": \"value\"}", "42")
+        TestConfig.database_properties, TestConfig.test_user, "{\"key\": \"value\"}", "42")
       end)
     {:ok, body_map} = Poison.decode body
     assert body_map["id"] == "42"
@@ -34,7 +33,7 @@ defmodule Couchdb.Connector.SecureWriterTest do
     TestPrep.secure_database
     {:ok, body, _headers} = retry_on_error(
       fn() -> Writer.create_generate(
-        TestConfig.database_properties, TestSupport.test_user, "{\"key\": \"value\"}")
+        TestConfig.database_properties, TestConfig.test_user, "{\"key\": \"value\"}")
       end)
     {:ok, body_map} = Poison.decode body
     assert String.starts_with?(body_map["rev"], "1-")
@@ -46,14 +45,14 @@ defmodule Couchdb.Connector.SecureWriterTest do
     {:ok, _body, headers} = retry_on_error(
       fn() ->
         Writer.create_generate(
-          TestConfig.database_properties, TestSupport.test_user, "{\"key\": \"original value\"}")
+          TestConfig.database_properties, TestConfig.test_user, "{\"key\": \"original value\"}")
       end)
     id = id_from_url(header_value(headers, "Location"))
     revision = header_value(headers, "ETag")
     update = "{\"_id\": \"#{id}\", \"_rev\": #{revision}, \"key\": \"new value\"}"
     {:ok, _body, headers} = retry_on_error(
       fn() ->
-        Writer.update(TestConfig.database_properties, TestSupport.test_user, update)
+        Writer.update(TestConfig.database_properties, TestConfig.test_user, update)
       end)
     assert String.starts_with?(header_value(headers, "ETag"), "\"2-")
   end
@@ -61,7 +60,7 @@ defmodule Couchdb.Connector.SecureWriterTest do
   test "update/3: verify that a document without id raises an exception" do
     update = "{\"_rev\": \"some_revision\", \"key\": \"new value\"}"
     assert_raise RuntimeError, fn ->
-      Writer.update(TestConfig.database_properties, TestSupport.test_user, update)
+      Writer.update(TestConfig.database_properties, TestConfig.test_user, update)
     end
   end
 
@@ -69,14 +68,14 @@ defmodule Couchdb.Connector.SecureWriterTest do
     TestPrep.secure_database
     {:ok, _body, headers} = retry_on_error(
       fn() -> Writer.create_generate(
-        TestConfig.database_properties, TestSupport.test_user, "{\"key\": \"original value\"}")
+        TestConfig.database_properties, TestConfig.test_user, "{\"key\": \"original value\"}")
       end)
     id = id_from_url(header_value(headers, "Location"))
     revision = header_value(headers, "ETag")
     update = "{\"_id\": \"#{id}\", \"_rev\": #{revision}, \"key\": \"new value\"}"
     {:ok, _body, headers} = retry_on_error(
       fn() -> Writer.update(
-        TestConfig.database_properties, TestSupport.test_user, update, id)
+        TestConfig.database_properties, TestConfig.test_user, update, id)
       end)
     assert String.starts_with?(header_value(headers, "ETag"), "\"2-")
   end
@@ -85,12 +84,12 @@ defmodule Couchdb.Connector.SecureWriterTest do
     TestPrep.secure_database
     {:ok, _, headers} = retry_on_error(
       fn() -> Writer.create(
-        TestConfig.database_properties, TestSupport.test_user, "{\"key\": \"value\"}", "42")
+        TestConfig.database_properties, TestConfig.test_user, "{\"key\": \"value\"}", "42")
       end)
     revision = String.replace(header_value(headers, "ETag"), "\"", "")
     {:ok, body} = retry_on_error(
       fn() -> Writer.destroy(
-        TestConfig.database_properties, TestSupport.test_user, "42", revision)
+        TestConfig.database_properties, TestConfig.test_user, "42", revision)
       end)
     {:ok, body_map} = Poison.decode body
     assert String.starts_with?(body_map["rev"], "2-")

--- a/test/couchdb_connector/view_test.exs
+++ b/test/couchdb_connector/view_test.exs
@@ -7,7 +7,6 @@ defmodule Couchdb.Connector.ViewTest do
   alias Couchdb.Connector.View
   alias Couchdb.Connector.TestConfig
   alias Couchdb.Connector.TestPrep
-  alias Couchdb.Connector.TestSupport
 
   setup context do
     TestPrep.ensure_database
@@ -39,7 +38,7 @@ defmodule Couchdb.Connector.ViewTest do
   test "document_by_key/3: ensure that view returns document for given key" do
     result = retry(@retries,
       fn(_) ->
-        View.document_by_key TestConfig.database_properties, TestSupport.test_view_key, :update_after
+        View.document_by_key TestConfig.database_properties, TestConfig.test_view_key, :update_after
       end,
       fn(response) ->
         case response do
@@ -61,7 +60,7 @@ defmodule Couchdb.Connector.ViewTest do
     key = "missing"
     result = retry(@retries,
       fn(_) ->
-        View.document_by_key TestConfig.database_properties, TestSupport.test_view_key(key), :update_after
+        View.document_by_key TestConfig.database_properties, TestConfig.test_view_key(key), :update_after
       end,
       fn(response) ->
         case response do
@@ -80,11 +79,11 @@ defmodule Couchdb.Connector.ViewTest do
   end
 
   test "document_by_key/2: ensure that function exists. document may or may not be found" do
-    View.document_by_key TestConfig.database_properties, TestSupport.test_view_key
+    View.document_by_key TestConfig.database_properties, TestConfig.test_view_key
   end
 
   test "document_by_key/3: ensure that function exists. document may or may not be found" do
-    View.document_by_key TestConfig.database_properties, TestSupport.test_view_key, :ok
+    View.document_by_key TestConfig.database_properties, TestConfig.test_view_key, :ok
   end
 
   test "document_by_key/5: ensure that view returns document for given key" do

--- a/test/couchdb_connector_view_test.exs
+++ b/test/couchdb_connector_view_test.exs
@@ -23,7 +23,7 @@ defmodule Couchdb.ConnectorViewTest do
   test "document_by_key/3: ensure that view returns document for given key" do
     result = retry(@retries,
       fn(_) ->
-        Connector.document_by_key(TestConfig.database_properties, TestSupport.test_view_key, :update_after)
+        Connector.document_by_key(TestConfig.database_properties, TestConfig.test_view_key, :update_after)
       end,
       fn(response) ->
         case response do
@@ -44,7 +44,7 @@ defmodule Couchdb.ConnectorViewTest do
     key = "missing"
     result = retry(@retries,
       fn(_) ->
-        Connector.document_by_key(TestConfig.database_properties, TestSupport.test_view_key(key), :update_after)
+        Connector.document_by_key(TestConfig.database_properties, TestConfig.test_view_key(key), :update_after)
       end,
       fn(response) ->
         case response do
@@ -75,7 +75,7 @@ defmodule Couchdb.ConnectorViewTest do
     TestPrep.secure_database()
     {:ok, result_map} = retry_on_error(
       fn() ->
-        Connector.fetch_all(TestConfig.database_properties, TestSupport.test_user, "test_view", "test_fetch")
+        Connector.fetch_all(TestConfig.database_properties, TestConfig.test_user, "test_view", "test_fetch")
       end)
     assert result_map["total_rows"] == 1
     [first|_] = result_map["rows"]
@@ -83,11 +83,11 @@ defmodule Couchdb.ConnectorViewTest do
   end
 
   test "document_by_key/2: ensure that function exists. document may or may not be found" do
-    Connector.document_by_key(TestConfig.database_properties, TestSupport.test_view_key)
+    Connector.document_by_key(TestConfig.database_properties, TestConfig.test_view_key)
   end
 
   test "document_by_key/3: ensure that function exists. document may or may not be found" do
-    Connector.document_by_key(TestConfig.database_properties, TestSupport.test_view_key, :ok)
+    Connector.document_by_key(TestConfig.database_properties, TestConfig.test_view_key, :ok)
   end
 
   test "document_by_key/4: ensure that view returns document for given key" do
@@ -95,7 +95,7 @@ defmodule Couchdb.ConnectorViewTest do
     result = retry(@retries,
       fn(_) ->
         Connector.document_by_key(
-          TestConfig.database_properties, TestSupport.test_user, TestSupport.test_view_key, :update_after
+          TestConfig.database_properties, TestConfig.test_user, TestConfig.test_view_key, :update_after
         )
       end,
       fn(response) ->
@@ -114,6 +114,6 @@ defmodule Couchdb.ConnectorViewTest do
   end
 
   test "document_by_key/4: ensure that function exists. document may or may not be found" do
-    Connector.document_by_key TestConfig.database_properties, TestSupport.test_user, TestSupport.test_view_key, :ok
+    Connector.document_by_key TestConfig.database_properties, TestConfig.test_user, TestConfig.test_view_key, :ok
   end
 end

--- a/test/test_config.exs
+++ b/test/test_config.exs
@@ -28,4 +28,20 @@ defmodule Couchdb.Connector.TestConfig do
         raise RuntimeError, message: "Error: #{inspect reason}"
     end
   end
+
+  def test_user do
+    %{user: "jan", password: "relax"}
+  end
+
+  def test_admin do
+    %{user: "anna", password: "secret"}
+  end
+
+  def test_view_key do
+    test_view_key("test_name")
+  end
+
+  def test_view_key(key) do
+    %{design: "test_view", view: "test_fetch", key: key}
+  end
 end

--- a/test/test_prep.exs
+++ b/test/test_prep.exs
@@ -30,26 +30,17 @@ defmodule Couchdb.Connector.TestPrep do
     end)
   end
 
-  # TODO: duplicate functions
-  defp test_admin do
-    %{user: "anna", password: "secret"}
-  end
-
-  defp test_user do
-    %{user: "jan", password: "relax"}
-  end
-
   def ensure_test_user do
     TestSupport.retry_on_error(fn() ->
-      Admin.create_user(TestConfig.database_properties(), test_admin(), test_user(), ["members"])
+      Admin.create_user(TestConfig.database_properties(), TestConfig.test_admin(), TestConfig.test_user(), ["members"])
     end)
   end
 
   def delete_test_user do
-    case Admin.user_info(TestConfig.database_properties(), test_admin(), "jan") do
+    case Admin.user_info(TestConfig.database_properties(), TestConfig.test_admin(), "jan") do
       {:ok, body} ->
         {:ok, body_map} = Poison.decode body
-        HTTPoison.delete UrlHelper.user_url(TestConfig.database_properties(), test_admin(), "jan")
+        HTTPoison.delete UrlHelper.user_url(TestConfig.database_properties(), TestConfig.test_admin(), "jan")
           <> "?rev=#{body_map["_rev"]}"
       {:error, body} ->
         {:error, body}
@@ -57,7 +48,7 @@ defmodule Couchdb.Connector.TestPrep do
   end
 
   def delete_test_admin do
-    case Admin.admin_info(TestConfig.database_properties(), test_admin()) do
+    case Admin.admin_info(TestConfig.database_properties(), TestConfig.test_admin()) do
       {:ok, _} ->
         HTTPoison.delete(UrlHelper.admin_url(TestConfig.database_properties(), "anna", "secret"))
       {:error, body} ->
@@ -67,13 +58,13 @@ defmodule Couchdb.Connector.TestPrep do
 
   def ensure_test_admin do
     TestSupport.retry_on_error(fn() ->
-      Admin.create_admin(TestConfig.database_properties(), test_admin())
+      Admin.create_admin(TestConfig.database_properties(), TestConfig.test_admin())
     end)
   end
 
   def ensure_test_security do
     TestSupport.retry_on_error(fn() ->
-      Admin.set_security(TestConfig.database_properties(), test_admin(), ["anna"], ["jan"])
+      Admin.set_security(TestConfig.database_properties(), TestConfig.test_admin(), ["anna"], ["jan"])
     end)
   end
 

--- a/test/test_support.exs
+++ b/test/test_support.exs
@@ -37,22 +37,6 @@ end
 defmodule Couchdb.Connector.TestSupport do
   require Logger
 
-  def test_user() do
-    %{user: "jan", password: "relax"}
-  end
-
-  def test_admin() do
-    %{user: "anna", password: "secret"}
-  end
-
-  def test_view_key do
-    test_view_key("test_name")
-  end
-
-  def test_view_key(key) do
-    %{design: "test_view", view: "test_fetch", key: key}
-  end
-
   # Couchdb sometimes surprises us with errors like this one:
   # {:error, %HTTPoison.Error{id: nil, reason: :closed}}
   # These closed connections happen a lot on Travis which makes triggers


### PR DESCRIPTION
This is a refactoring that merges the auth information in the db_properties type.

The main advantage is, that now every action can be executed authenticated or non-authenticated. It dramatically decreases overhead in new features and testing.

Old methods remain with deprecation warnings. Tests now spit out a lot of deprecation. I'd like to fix that in a separate PR.